### PR TITLE
add flatpak support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,9 @@ yarn.lock
 /draft*.md
 /scratch*.md
 /*.local.md
+
+/flatpak/hoard.deb
+/flatpak/hoard.flatpak
+/flatpak/build-dir/
+/flatpak/repo/
+/flatpak/.flatpak-builder/

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,13 @@ CONTRIBUTING.md
 *.db-wal
 *.db-shm
 
+# Flatpak
+/flatpak/hoard.deb
+/flatpak/hoard.flatpak
+/flatpak/build-dir/
+/flatpak/repo/
+/flatpak/.flatpak-builder/
+
 # Tauri
 crates/hoard-desktop/gen/
 
@@ -118,9 +125,3 @@ yarn.lock
 /draft*.md
 /scratch*.md
 /*.local.md
-
-/flatpak/hoard.deb
-/flatpak/hoard.flatpak
-/flatpak/build-dir/
-/flatpak/repo/
-/flatpak/.flatpak-builder/

--- a/crates/hoard-desktop/src/lib.rs
+++ b/crates/hoard-desktop/src/lib.rs
@@ -374,12 +374,31 @@ pub fn run() {
             // shouldn't kill the app — Linux desktops without an AppIndicator
             // host (some minimal Wayland sessions) will reject our tray and
             // we want to keep running with just the window visible.
-            if let Err(e) = tray::install(&app.handle().clone()) {
-                tracing::warn!(error = %e, "couldn't install tray icon");
-            } else {
-                // Apply offline as the initial state — the agent forwarder
-                // will recolour to idle as soon as it boots.
-                app.state::<TrayController>().set_state(TrayState::Offline);
+            //
+            // A missing libayatana-appindicator3/libappindicator3 (no distro
+            // package, or a Flatpak runtime that doesn't ship it) doesn't
+            // surface as an `Err` here: `libappindicator-sys` panics straight
+            // out of its dlopen check instead, which skips right past the
+            // `Result` handling below. `catch_unwind` is what actually
+            // delivers on the comment above in that case.
+            let tray_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                tray::install(&app.handle().clone())
+            }));
+            match tray_result {
+                Ok(Ok(())) => {
+                    // Apply offline as the initial state — the agent forwarder
+                    // will recolour to idle as soon as it boots.
+                    app.state::<TrayController>().set_state(TrayState::Offline);
+                }
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "couldn't install tray icon");
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "tray icon backend panicked (missing libayatana-appindicator3 / \
+                         libappindicator3?) — continuing without a tray icon"
+                    );
+                }
             }
 
             // First-run bootstrap + silent-boot handling. `prefs.json` missing
@@ -546,10 +565,15 @@ pub fn run() {
             // `cargo tauri dev` (no installer) we have to register at
             // runtime so the OS knows to dispatch `hoard://…` to us. This
             // is a no-op when the scheme is already registered.
+            //
+            // Skipped entirely under Flatpak: since flatpak registers through
+            // the .desktop file.
             #[cfg(any(target_os = "linux", windows))]
             {
-                if let Err(e) = app.deep_link().register("hoard") {
-                    tracing::warn!(error = %e, "couldn't register hoard:// scheme at runtime");
+                if !running_under_flatpak() {
+                    if let Err(e) = app.deep_link().register("hoard") {
+                        tracing::warn!(error = %e, "couldn't register hoard:// scheme at runtime");
+                    }
                 }
             }
             Ok(())
@@ -607,6 +631,11 @@ pub fn run() {
 /// flags), so we scan rather than index.
 fn first_hoard_url<I: IntoIterator<Item = String>>(args: I) -> Option<String> {
     args.into_iter().find(|a| a.starts_with("hoard://"))
+}
+
+#[cfg(any(target_os = "linux", windows))]
+fn running_under_flatpak() -> bool {
+    std::env::var_os("FLATPAK_ID").is_some() || std::path::Path::new("/.flatpak-info").exists()
 }
 
 /// Stash a `hoard://` URL where the frontend can find it and, optionally,

--- a/crates/hoard-desktop/ui/package.json
+++ b/crates/hoard-desktop/ui/package.json
@@ -34,5 +34,8 @@
     "tslib": "^2.8.1",
     "typescript": "^5.9.3",
     "vite": "^8.2.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/crates/hoard-desktop/ui/pnpm-workspace.yaml
+++ b/crates/hoard-desktop/ui/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  es5-ext: false

--- a/crates/hoard-desktop/ui/pnpm-workspace.yaml
+++ b/crates/hoard-desktop/ui/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  es5-ext: false

--- a/flatpak/services.hoard.saves.metainfo.xml
+++ b/flatpak/services.hoard.saves.metainfo.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata for the Hoard Flatpak. Values below are pulled from
+  crates/hoard-desktop/tauri.conf.json (shortDescription, longDescription,
+  homepage, category) and Cargo.toml (license) rather than invented — keep
+  the two in sync when either changes.
+
+  No <screenshots> block: Flathub requires one for submission review, but a
+  local flatpak-builder build doesn't. Add real, hosted screenshot URLs here
+  before submitting.
+-->
+<component type="desktop-application">
+  <id>services.hoard.saves</id>
+  <launchable type="desktop-id">services.hoard.saves.desktop</launchable>
+  <name>Hoard</name>
+  <summary>Self-hosted cloud sync for game saves</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-only</project_license>
+
+  <developer id="dev.hoard">
+    <name>Hoard</name>
+  </developer>
+
+  <url type="homepage">https://github.com/rleeon/hoard</url>
+  <url type="bugtracker">https://github.com/rleeon/hoard/issues</url>
+
+  <description>
+    <p>
+      Hoard syncs your game saves to your own server. Auto-detect games,
+      auto-backup when you stop playing, restore previous versions any time.
+    </p>
+  </description>
+
+  <categories>
+    <category>Utility</category>
+  </categories>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+
+  <content_rating type="oars-1.1" />
+
+  <!--
+    Flathub submission requires at least one <release> with a real date; the
+    version numbers in Cargo.toml and CHANGELOG.md aren't the same counter
+    (this is a workspace-wide version, that's a per-app one), so add the
+    actual release you're shipping rather than guessing one here, e.g.:
+    <releases>
+      <release version="7.7.8" date="YYYY-MM-DD" />
+    </releases>
+  -->
+</component>

--- a/flatpak/services.hoard.saves.yml
+++ b/flatpak/services.hoard.saves.yml
@@ -26,6 +26,12 @@ finish-args:
   # Tray icon (tauri-plugin global tray + the community/Pro overlay toggle).
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-run/tray-icon:create
+  # The daemon keeps the cloud token in the OS credential store, which on Linux
+  # is libsecret over the session bus (see the `keyring` features in
+  # crates/hoard-agent/Cargo.toml). Without this name the store is simply
+  # absent, credentials.rs falls back to a 0600 file inside the sandbox, and
+  # nothing says out loud that the token stopped being encrypted at rest.
+  - --talk-name=org.freedesktop.secrets
   # Hoard's whole job is finding and backing up game saves wherever they live:
   # Steam libraries on other drives, Proton/Wine prefixes, emulator save
   # folders, self-chosen paths. See crates/hoard-agent/src/{steam,roots,

--- a/flatpak/services.hoard.saves.yml
+++ b/flatpak/services.hoard.saves.yml
@@ -1,0 +1,84 @@
+# Flatpak manifest for Hoard, built with the "closed source" / binary-extraction
+# recipe from the official Tauri docs (https://v2.tauri.app/distribute/flatpak/):
+# build the app's own .deb the normal way, then unpack it into /app instead of
+# re-building Rust + the frontend inside the sandbox. Driven by
+# scripts/build-flatpak.sh, which builds the .deb and then runs flatpak-builder
+# against this file.
+#
+# The Flatpak id (services.hoard.saves) is intentionally its own reverse-DNS name,
+# distinct from the Tauri `identifier` in tauri.conf.json (dev.hoard.desktop),
+# which stays as-is since it's load-bearing for deep links (`hoard://`) and
+# the updater — only the Flatpak wrapper needs the services.hoard.saves name.
+id: services.hoard.saves
+
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+
+command: hoard-desktop
+
+finish-args:
+  - --socket=wayland # show the window on Wayland
+  - --socket=fallback-x11 # show the window under X11 / XWayland
+  - --device=dri # GPU accel for the webview
+  - --share=ipc # webkit shared-memory requirement
+  - --share=network # cloud sync (self-hosted or Hoard Cloud)
+  # Tray icon (tauri-plugin global tray + the community/Pro overlay toggle).
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --filesystem=xdg-run/tray-icon:create
+  # Hoard's whole job is finding and backing up game saves wherever they live:
+  # Steam libraries on other drives, Proton/Wine prefixes, emulator save
+  # folders, self-chosen paths. See crates/hoard-agent/src/{steam,roots,
+  # wine_prefixes}.rs. That's arbitrary host paths, not just $HOME, so this
+  # needs the broad grant rather than a handful of --filesystem entries that
+  # would silently miss whichever drive a game happens to be installed on.
+  - --filesystem=host
+
+modules:
+  - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+
+  - name: hoard-desktop
+    buildsystem: simple
+
+    sources:
+      - type: file
+        path: hoard.deb
+      - type: file
+        path: services.hoard.saves.metainfo.xml
+
+    build-commands:
+      - set -e
+
+      # Unpack the .deb (ar container + a data.tar.* with whatever compression
+      # the local dpkg-deb used).
+      - mkdir -p deb-extract
+      - ar -x hoard.deb --output deb-extract
+      - tar -C deb-extract -xf deb-extract/data.tar.*
+
+      # Main binary plus every externalBin sidecar (hoardd, hoard-screen, hoard
+      # CLI) the bundler drops next to it — hoardd::client::own_daemon_binary
+      # and the screen sidecar both resolve as a bare-named sibling of
+      # current_exe, so they all need to land in the same /app/bin.
+      - |
+        for bin in deb-extract/usr/bin/*; do
+          install -Dm755 "$bin" "/app/bin/$(basename "$bin")"
+        done
+
+      # Desktop entry, repointed at the icon name we install below. Left
+      # otherwise untouched so the MimeType=x-scheme-handler/hoard; line the
+      # deep-link plugin adds at bundle time survives into the sandbox.
+      - |
+        desktop_src="$(ls deb-extract/usr/share/applications/*.desktop | head -n1)"
+        sed 's/^Icon=.*/Icon=services.hoard.saves/' "$desktop_src" > services.hoard.saves.desktop
+        install -Dm644 services.hoard.saves.desktop /app/share/applications/services.hoard.saves.desktop
+
+      # Icons, renamed to the flatpak id so the icon theme resolves them.
+      - |
+        for dir in deb-extract/usr/share/icons/hicolor/*/apps; do
+          size="$(basename "$(dirname "$dir")")"
+          src="$(ls "$dir"/* | head -n1)"
+          ext="${src##*.}"
+          install -Dm644 "$src" "/app/share/icons/hicolor/$size/apps/services.hoard.saves.$ext"
+        done
+
+      - install -Dm644 services.hoard.saves.metainfo.xml /app/share/metainfo/services.hoard.saves.metainfo.xml

--- a/flatpak/shared-modules/README.md
+++ b/flatpak/shared-modules/README.md
@@ -1,0 +1,1 @@
+Vendored in from https://github.com/flathub/shared-modules

--- a/flatpak/shared-modules/dbus-glib/dbus-glib.json
+++ b/flatpak/shared-modules/dbus-glib/dbus-glib.json
@@ -1,0 +1,29 @@
+{
+    "name": "dbus-glib",
+    "cleanup": [
+        "*.la",
+        "/bin",
+        "/etc",
+        "/include",
+        "/lib/pkgconfig",
+        "/libexec",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
+    "config-opts": [
+        "--disable-static",
+        "--disable-gtk-doc"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.114.tar.gz",
+            "sha256": "c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": 1979,
+                "url-template": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-$version.tar.gz"
+            }
+        }
+    ]
+}

--- a/flatpak/shared-modules/intltool/intltool-0.51.json
+++ b/flatpak/shared-modules/intltool/intltool-0.51.json
@@ -1,0 +1,20 @@
+{
+  "name": "intltool",
+  "cleanup": [ "*" ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+      "mirror-urls": [
+        "https://sources.suse.com/SUSE:SLE-15-SP7:Update:BCI/000product/ca527df4d03bf96a67854a8ed2f0c64b/INCLUDED/SUSE:SLE-15-SP6:GA::intltool::45f77273c3f2ef792fa697b444183beb/intltool-0.51.0.tar.gz",
+        "https://mirror-hk.koddos.net/lfs/lfs-packages/12.0/intltool-0.51.0.tar.gz",
+        "https://gstreamer.freedesktop.org/src/mirror/intltool-0.51.0.tar.gz"
+      ],
+      "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+    },
+    {
+      "type": "patch",
+      "path": "intltool-perl5.26-regex-fixes.patch"
+    }
+  ]
+}

--- a/flatpak/shared-modules/intltool/intltool-perl5.26-regex-fixes.patch
+++ b/flatpak/shared-modules/intltool/intltool-perl5.26-regex-fixes.patch
@@ -1,0 +1,59 @@
+Description: Escape "{", to prevent complaints from perl 5.22 and 5.26
+Author: Roderich Schupp <roderich.schupp@gmail.com>
+Author: gregor herrmann <gregoa@debian.org>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788705
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826471
+Bug-Upstream: https://bugs.launchpad.net/intltool/+bug/1490906
+
+Index: intltool-0.51.0/intltool-update.in
+===================================================================
+--- intltool-0.51.0.orig/intltool-update.in	2017-07-23 17:24:35.113169465 +0200
++++ intltool-0.51.0/intltool-update.in	2017-07-23 17:24:35.109169052 +0200
+@@ -1062,13 +1062,13 @@
+ 	}
+     }
+ 
+-    if ($str =~ /^(.*)\${?([A-Z_]+)}?(.*)$/)
++    if ($str =~ /^(.*)\$\{?([A-Z_]+)}?(.*)$/)
+     {
+ 	my $rest = $3;
+ 	my $untouched = $1;
+ 	my $sub = "";
+         # Ignore recursive definitions of variables
+-        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\${?$2}?/;
++        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\$\{?$2}?/;
+ 
+ 	return SubstituteVariable ("$untouched$sub$rest");
+     }
+@@ -1190,10 +1190,10 @@
+ 	$name    =~ s/\(+$//g;
+ 	$version =~ s/\(+$//g;
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
+     }
+ 
+     if ($conf_source =~ /^AC_INIT\(([^,\)]+),([^,\)]+)[,]?([^,\)]+)?/m)
+@@ -1219,11 +1219,11 @@
+ 	$version =~ s/\(+$//g;
+         $bugurl  =~ s/\(+$//g if (defined $bugurl);
+ 
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
+-        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\${?\w+}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
++        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\$\{?\w+}?/);
+     }
+ 
+     # \s makes this not work, why?

--- a/flatpak/shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+++ b/flatpak/shared-modules/libappindicator/libappindicator-gtk3-12.10.json
@@ -1,0 +1,140 @@
+{
+  "name": "libappindicator",
+  "build-options": {
+    "cflags": "-Wno-error",
+    "make-args": [ "-j1" ],
+    "env": {
+      "GTKDOCIZE": "true"
+    }
+  },
+  "rm-configure": true,
+  "config-opts": [
+    "--disable-static",
+    "--disable-gtk-doc",
+    "--disable-tests",
+    "--disable-mono-tests",
+    "--enable-introspection=no",
+    "--with-gtk=3"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/lib/*.la",
+    "/share/gtk-doc",
+    "/share/gir-1.0"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://launchpad.net/libappindicator/12.10/12.10.0/+download/libappindicator-12.10.0.tar.gz",
+      "mirror-urls": [
+        "https://mirror.math.princeton.edu/pub/frugalware/frugalware-2.1/source/xlib-extra/libappindicator/libappindicator-12.10.0.tar.gz",
+        "https://distfiles.alpinelinux.org/distfiles/v3.12/libappindicator-12.10.0.tar.gz",
+        "https://ftp.fr.openbsd.org/pub/OpenBSD/distfiles/libappindicator-12.10.0.tar.gz"
+      ],
+      "sha256": "d5907c1f98084acf28fd19593cb70672caa0ca1cf82d747ba6f4830d4cc3b49f"
+    },
+    {
+      "type": "patch",
+      "paths": [
+        "patches/0001-libappindicator-ftbfs.patch",
+        "patches/0002-libappindicator-no-python.patch",
+        "patches/0003-libappindicator-fix-crash-from-incorrect-signal-emission.patch",
+        "patches/0004-libappindicator-fix-crash-iterating-icon-themes.patch"
+      ]
+    },
+    {
+      "type": "script",
+      "commands": ["autoreconf -sfi"],
+      "dest-filename": "autogen.sh"
+    }
+  ],
+  "modules": [
+    "../intltool/intltool-0.51.json",
+    "../dbus-glib/dbus-glib.json",
+    {
+      "name": "libdbusmenu",
+      "build-options": {
+        "cflags": "-Wno-error",
+        "env": {
+          "HAVE_VALGRIND_FALSE": "#",
+          "HAVE_VALGRIND_TRUE": ""
+        }
+      },
+      "cleanup": [
+        "/include",
+        "/libexec",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/share/doc",
+        "/share/libdbusmenu",
+        "/share/gtk-doc",
+        "/share/gir-1.0"
+      ],
+      "config-opts": [
+        "--disable-static",
+        "--disable-gtk-doc",
+        "--enable-introspection=no",
+        "--disable-vala",
+        "--disable-dumper",
+        "--disable-tests",
+        "--with-gtk=3"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
+          "mirror-urls": [
+            "https://sources.suse.com/SUSE:SLFO:Main:Build/libdbusmenu/a5b3e4717f09f90f9cd5568a5f933e8d/libdbusmenu-16.04.0.tar.gz",
+            "https://mirror.math.princeton.edu/pub/frugalware/frugalware-2.1/source/xlib/libdbusmenu/libdbusmenu-16.04.0.tar.gz",
+            "https://ftp.fr.openbsd.org/pub/OpenBSD/distfiles/libdbusmenu-16.04.0.tar.gz"
+          ],
+          "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+        }
+      ]
+    },
+    {
+      "name": "libindicator",
+      "build-options": {
+        "cflags": "-Wno-error"
+      },
+      "cleanup": [
+        "/include",
+        "/libexec",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/share/libindicator",
+        "/share/gtk-doc",
+        "/share/gir-1.0"
+      ],
+      "config-opts": [
+        "--disable-static",
+        "--disable-tests",
+        "--with-gtk=3"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://launchpad.net/libindicator/12.10/12.10.1/+download/libindicator-12.10.1.tar.gz",
+          "mirror-urls": [
+            "https://ftp.fr.openbsd.org/pub/OpenBSD/distfiles/libindicator-12.10.1.tar.gz",
+            "https://distfiles.alpinelinux.org/distfiles/v3.11/libindicator-12.10.1.tar.gz"
+          ],
+          "sha256": "b2d2e44c10313d5c9cd60db455d520f80b36dc39562df079a3f29495e8f9447f"
+        },
+        {
+          "type": "shell",
+          "commands": [
+            "# FTBFS fix",
+            "sed -e '/LIBINDICATOR_LIBS/ s/\\$LIBM/ $LIBM/' -i configure.ac"
+          ]
+        },
+        {
+          "type": "script",
+          "commands": ["autoreconf -sfi"],
+          "dest-filename": "autogen.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/flatpak/shared-modules/libappindicator/patches/0001-libappindicator-ftbfs.patch
+++ b/flatpak/shared-modules/libappindicator/patches/0001-libappindicator-ftbfs.patch
@@ -1,0 +1,20 @@
+From: Olivier Tilloy <olivier.tilloy@canonical.com>
+Date: Tue 2018-03-20 12:47:56 +0000
+Subject: [PATCH] libappindicator FTBFS on bionic
+
+Fix build failures on bionic,
+and update Vcs-* fields in debian/control. (LP: #1757121)
+
+Approved by: Marco Trevisan (Treviño)
+---
+--- libappindicator-12.10.0/src/app-indicator.c	2017-02-15 14:10:41 +0000
++++ libappindicator-12.10.0/src/app-indicator.c	2018-03-20 12:38:59 +0000
+@@ -2196,7 +2196,7 @@ app_indicator_set_secondary_activate_tar
+ 
+ 	g_return_if_fail (GTK_IS_WIDGET (menuitem));
+ 
+-	priv->sec_activate_target = g_object_ref(G_OBJECT(menuitem));
++	priv->sec_activate_target = g_object_ref(menuitem);
+ 	priv->sec_activate_enabled = widget_is_menu_child(self, menuitem);
+ 	g_signal_connect(menuitem, "parent-set", G_CALLBACK(sec_activate_target_parent_changed), self);
+ }

--- a/flatpak/shared-modules/libappindicator/patches/0002-libappindicator-no-python.patch
+++ b/flatpak/shared-modules/libappindicator/patches/0002-libappindicator-no-python.patch
@@ -1,0 +1,888 @@
+diff --git a/bindings/Makefile.am b/bindings/Makefile.am
+index d1f6d73..dccca6c 100644
+--- a/bindings/Makefile.am
++++ b/bindings/Makefile.am
+@@ -3,7 +3,6 @@ SUBDIRS =	\
+ 	vala
+ else
+ SUBDIRS =		\
+-	python		\
+ 	vala
+ endif
+ 
+diff --git a/bindings/python/Makefile.am b/bindings/python/Makefile.am
+deleted file mode 100644
+index fe95c02..0000000
+--- a/bindings/python/Makefile.am
++++ /dev/null
+@@ -1,39 +0,0 @@
+-defsdir = $(datadir)/pygtk/2.0/defs
+-defs_DATA = appindicator.defs
+-
+-#CFLAGS = -Wall -Werror
+-INCLUDES = \
+-		-I$(top_srcdir)/src \
+-        -DG_LOG_DOMAIN=\"appindicator-python\" \
+-        -DDATADIR=\"$(datadir)\" \
+-        -DLIBDIR=\"$(libdir)\" \
+-        $(APPINDICATOR_PYTHON_CFLAGS) \
+-        $(PYTHON_INCLUDES)
+-
+-pkgpythondir = $(pyexecdir)
+-pkgpyexecdir = $(pyexecdir)
+-
+-pkgappindicatordir = $(pkgpythondir)/appindicator
+-pkgappindicator_PYTHON = __init__.py
+-
+-appindicatordir = $(pkgpyexecdir)/appindicator
+-appindicator_LTLIBRARIES = _appindicator.la
+-
+-_appindicator_la_LDFLAGS = -module -avoid-version -export-symbols-regex init_appindicator
+-_appindicator_la_LIBADD = $(APPINDICATOR_PYTHON_LIBS) -L$(top_builddir)/src/.libs -lappindicator
+-_appindicator_la_SOURCES = appindicatormodule.c
+-nodist__appindicator_la_SOURCES = appindicator.c
+-
+-CLEANFILES = appindicator.c
+-EXTRA_DIST = appindicator.override.in appindicator-arg-types.py $(defs_DATA)
+-appindicator.c: $(defs_DATA) appindicator.override
+-
+-%.c: %.defs
+-	($(PYGTK_CODEGEN) \
+-		--register $(PYGTK_DEFSDIR)/gtk-types.defs \
+-		--register $(PYGTK_DEFSDIR)/gdk-types.defs \
+-		--load-types $(srcdir)/appindicator-arg-types.py \
+-	    --override $*.override \
+-	    --prefix py$* $(srcdir)/$*.defs) > gen-$*.c \
+-	 && cp gen-$*.c $*.c \
+-	 && rm -f gen-$*.c
+diff --git a/bindings/python/__init__.py b/bindings/python/__init__.py
+deleted file mode 100644
+index 20e2140..0000000
+--- a/bindings/python/__init__.py
++++ /dev/null
+@@ -1,27 +0,0 @@
+-# Python bindings for libappindicator.
+-# 
+-# Copyright 2009 Canonical Ltd.
+-# 
+-# Authors:
+-#     Eitan Isaacson <eitan@ascender.com>
+-#     Neil Jagdish Patel <neil.patel@canonical.com>
+-# 
+-# This program is free software: you can redistribute it and/or modify it 
+-# under the terms of either or both of the following licenses:
+-# 
+-# 1) the GNU Lesser General Public License version 3, as published by the 
+-# Free Software Foundation; and/or
+-# 2) the GNU Lesser General Public License version 2.1, as published by 
+-# the Free Software Foundation.
+-# 
+-# This program is distributed in the hope that it will be useful, but 
+-# WITHOUT ANY WARRANTY; without even the implied warranties of 
+-# MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR 
+-# PURPOSE.  See the applicable version of the GNU Lesser General Public 
+-# License for more details.
+-# 
+-# You should have received a copy of both the GNU Lesser General Public 
+-# License version 3 and version 2.1 along with this program.  If not, see 
+-# <http://www.gnu.org/licenses/>
+-
+-from _appindicator import *
+diff --git a/bindings/python/appindicator-arg-types.py b/bindings/python/appindicator-arg-types.py
+deleted file mode 100644
+index 9d74aa0..0000000
+--- a/bindings/python/appindicator-arg-types.py
++++ /dev/null
+@@ -1,27 +0,0 @@
+-# Python bindings for libappindicator.
+-# 
+-# Copyright 2009 Canonical Ltd.
+-# 
+-# Authors:
+-#     Eitan Isaacson <eitan@ascender.com>
+-# 
+-# This program is free software: you can redistribute it and/or modify it 
+-# under the terms of either or both of the following licenses:
+-# 
+-# 1) the GNU Lesser General Public License version 3, as published by the 
+-# Free Software Foundation; and/or
+-# 2) the GNU Lesser General Public License version 2.1, as published by 
+-# the Free Software Foundation.
+-# 
+-# This program is distributed in the hope that it will be useful, but 
+-# WITHOUT ANY WARRANTY; without even the implied warranties of 
+-# MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR 
+-# PURPOSE.  See the applicable version of the GNU Lesser General Public 
+-# License for more details.
+-# 
+-# You should have received a copy of both the GNU Lesser General Public 
+-# License version 3 and version 2.1 along with this program.  If not, see 
+-# <http://www.gnu.org/licenses/>
+-
+-import argtypes
+-
+diff --git a/bindings/python/appindicator.defs b/bindings/python/appindicator.defs
+deleted file mode 100644
+index 4fcc2d5..0000000
+--- a/bindings/python/appindicator.defs
++++ /dev/null
+@@ -1,200 +0,0 @@
+-;; -*- scheme -*-
+-; object definitions ...
+-(define-object Indicator
+-  (in-module "App")
+-  (parent "GObject")
+-  (c-name "AppIndicator")
+-  (gtype-id "APP_TYPE_INDICATOR")
+-)
+-
+-;; Enumerations and flags ...
+-
+-(define-enum IndicatorCategory
+-  (in-module "App")
+-  (c-name "AppIndicatorCategory")
+-  (gtype-id "APP_INDICATOR_TYPE_INDICATOR_CATEGORY")
+-  (values
+-    '("ApplicationStatus" "APP_INDICATOR_CATEGORY_APPLICATION_STATUS")
+-    '("Communications" "APP_INDICATOR_CATEGORY_COMMUNICATIONS")
+-    '("SystemServices" "APP_INDICATOR_CATEGORY_SYSTEM_SERVICES")
+-    '("Hardware" "APP_INDICATOR_CATEGORY_HARDWARE")
+-    '("Other" "APP_INDICATOR_CATEGORY_OTHER")
+-  )
+-)
+-
+-(define-enum IndicatorStatus
+-  (in-module "App")
+-  (c-name "AppIndicatorStatus")
+-  (gtype-id "APP_INDICATOR_TYPE_INDICATOR_STATUS")
+-  (values
+-    '("Passive" "APP_INDICATOR_STATUS_PASSIVE")
+-    '("Active" "APP_INDICATOR_STATUS_ACTIVE")
+-    '("NeedsAttention" "APP_INDICATOR_STATUS_ATTENTION")
+-  )
+-)
+-
+-;; From app-indicator.h
+-
+-(define-function app_indicator_get_type
+-  (c-name "app_indicator_get_type")
+-  (return-type "GType")
+-)
+-
+-(define-function app_indicator_new_with_path
+-  (c-name "app_indicator_new_with_path")
+-  (is-constructor-of "AppIndicator")
+-  (return-type "AppIndicator*")
+-  (parameters
+-    '("const-gchar*" "id")
+-    '("const-gchar*" "icon_name")
+-    '("AppIndicatorCategory" "category")
+-    '("const-gchar*" "icon_theme_path" (null-ok) (default "NULL"))
+-  )
+-)
+-
+-(define-method set_status
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_status")
+-  (return-type "none")
+-  (parameters
+-    '("AppIndicatorStatus" "status")
+-  )
+-)
+-
+-(define-method set_attention_icon
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_attention_icon_full")
+-  (return-type "none")
+-  (parameters
+-    '("const-gchar*" "icon_name")
+-    '("const-gchar*" "icon_desc" (null-ok) (default "NULL"))
+-  )
+-)
+-
+-(define-method set_menu
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_menu")
+-  (return-type "none")
+-  (parameters
+-    '("GtkMenu*" "menu")
+-  )
+-)
+-
+-(define-method set_icon
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_icon_full")
+-  (return-type "none")
+-  (parameters
+-    '("const-gchar*" "icon_name")
+-    '("const-gchar*" "icon_desc" (null-ok) (default "NULL"))
+-  )
+-)
+-
+-(define-method set_label
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_label")
+-  (return-type "none")
+-  (parameters
+-    '("const-gchar*" "label" (null-ok))
+-    '("const-gchar*" "guide" (null-ok) (default "NULL"))
+-  )
+-)
+-
+-(define-method set_ordering_index
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_ordering_index")
+-  (parameters
+-    '("guint32" "ordering_index")
+-  )
+-)
+-
+-(define-method set_icon_theme_path
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_set_icon_theme_path")
+-  (return-type "none")
+-  (parameters
+-    '("const-gchar*" "icon_theme_path" (null-ok))
+-  )
+-)
+-
+-(define-method get_id
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_id")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_category
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_category")
+-  (return-type "AppIndicatorCategory")
+-)
+-
+-(define-method get_status
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_status")
+-  (return-type "AppIndicatorStatus")
+-)
+-
+-(define-method get_icon
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_icon")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_icon_desc
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_icon_desc")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_icon_theme_path
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_icon_theme_path")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_attention_icon
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_attention_icon")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_attention_icon_desc
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_attention_icon_desc")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_menu
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_menu")
+-  (return-type "GtkMenu*")
+-)
+-
+-(define-method get_label
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_label")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_label_guide
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_label_guide")
+-  (return-type "const-gchar*")
+-)
+-
+-(define-method get_ordering_index
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_get_ordering_index")
+-  (return-type "guint32")
+-)
+-
+-(define-method build_menu_from_desktop
+-  (of-object "AppIndicator")
+-  (c-name "app_indicator_build_menu_from_desktop")
+-  (return-type "none")
+-  (parameters
+-    '("const-gchar*" "desktop_file")
+-    '("const-gchar*" "desktop_profile")
+-  )
+-)
+diff --git a/bindings/python/appindicator.override.in b/bindings/python/appindicator.override.in
+deleted file mode 100644
+index 84d3159..0000000
+--- a/bindings/python/appindicator.override.in
++++ /dev/null
+@@ -1,65 +0,0 @@
+-/*
+-Python bindings for libappindicator.
+-
+-Copyright 2009 Canonical Ltd.
+-
+-Authors:
+-    Eitan Isaacson <eitan@ascender.com> (original)
+-    Neil Jagdish Patel <neil.patel@canonical.com>
+-
+-This program is free software: you can redistribute it and/or modify it 
+-under the terms of either or both of the following licenses:
+-
+-1) the GNU Lesser General Public License version 3, as published by the 
+-Free Software Foundation; and/or
+-2) the GNU Lesser General Public License version 2.1, as published by 
+-the Free Software Foundation.
+-
+-This program is distributed in the hope that it will be useful, but 
+-WITHOUT ANY WARRANTY; without even the implied warranties of 
+-MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR 
+-PURPOSE.  See the applicable version of the GNU Lesser General Public 
+-License for more details.
+-
+-You should have received a copy of both the GNU Lesser General Public 
+-License version 3 and version 2.1 along with this program.  If not, see 
+-<http://www.gnu.org/licenses/>
+-*/
+-%%
+-headers
+-#include <Python.h>
+-#include "@top_srcdir@/src/app-indicator.h"
+-#include "@top_builddir@/src/app-indicator-enum-types.h"
+-#include <glib.h>
+-#include "pygobject.h"
+-#include "pyglib.h"
+-#include <pygtk/pygtk.h>
+-
+-typedef PyObject* (*to_pyobject_func) (gpointer data);
+-
+-#define APP_TYPE_INDICATOR APP_INDICATOR_TYPE
+-
+-void
+-_appindicator_add_constants(PyObject *module, const gchar *strip_prefix)
+-{
+-#ifdef VERSION
+-        PyModule_AddStringConstant(module, "__version__", VERSION);
+-#endif
+-        pyg_enum_add(module,
+-                     "IndicatorCategory", 
+-                     strip_prefix,
+-                     APP_INDICATOR_TYPE_INDICATOR_CATEGORY);
+-
+-        pyg_enum_add(module,
+-                     "IndicatorStatus", 
+-                     strip_prefix,
+-                     APP_INDICATOR_TYPE_INDICATOR_STATUS);
+-
+-        if (PyErr_Occurred())
+-                PyErr_Print();
+-}
+-%%
+-modulename appindicator
+-%%
+-import gobject.GObject as PyGObject_Type
+-import gtk.Menu as PyGtkMenu_Type
+diff --git a/bindings/python/appindicatormodule.c b/bindings/python/appindicatormodule.c
+deleted file mode 100644
+index b66639c..0000000
+--- a/bindings/python/appindicatormodule.c
++++ /dev/null
+@@ -1,49 +0,0 @@
+-/*
+-Python bindings for libappindicator.
+-
+-Copyright 2009 Canonical Ltd.
+-
+-Authors:
+-    Eitan Isaacson <eitan@ascender.com>
+-    Neil Jagdish Patel <neil.patel@canonical.com>
+-
+-This program is free software: you can redistribute it and/or modify it 
+-under the terms of either or both of the following licenses:
+-
+-1) the GNU Lesser General Public License version 3, as published by the 
+-Free Software Foundation; and/or
+-2) the GNU Lesser General Public License version 2.1, as published by 
+-the Free Software Foundation.
+-
+-This program is distributed in the hope that it will be useful, but 
+-WITHOUT ANY WARRANTY; without even the implied warranties of 
+-MERCHANTABILITY, SATISFACTORY QUALITY or FITNESS FOR A PARTICULAR 
+-PURPOSE.  See the applicable version of the GNU Lesser General Public 
+-License for more details.
+-
+-You should have received a copy of both the GNU Lesser General Public 
+-License version 3 and version 2.1 along with this program.  If not, see 
+-<http://www.gnu.org/licenses/>
+-*/
+-#include <pygobject.h>
+- 
+-void pyappindicator_register_classes (PyObject *d); 
+-extern PyMethodDef pyappindicator_functions[];
+-
+-DL_EXPORT(void)
+-init_appindicator(void)
+-{
+-		PyObject *m, *d;
+-		
+-		init_pygobject ();
+-		
+-		m = Py_InitModule ("_appindicator", pyappindicator_functions);
+-		d = PyModule_GetDict (m);
+-		
+-		pyappindicator_register_classes (d);
+-
+-		_appindicator_add_constants (m, "APP_INDICATOR_");
+-		if (PyErr_Occurred ()) {
+-				Py_FatalError ("can't initialise module appindicator");
+-		}
+-}
+diff --git a/configure b/configure
+index 5174b3f..8ff732c 100755
+--- a/configure
++++ b/configure
+@@ -13703,363 +13703,6 @@ else
+ fi
+ 
+ 
+-###########################
+-# Python
+-###########################
+-
+-PYGTK_REQUIRED=2.14.0
+-PYGOBJECT_REQUIRED=0.22
+-
+-
+-
+-
+-
+-        if test -n "$PYTHON"; then
+-      # If the user set $PYTHON, use it and don't search something else.
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $PYTHON version >= 2.3.5" >&5
+-$as_echo_n "checking whether $PYTHON version >= 2.3.5... " >&6; }
+-      prog="import sys, string
+-# split strings by '.' and convert to numeric.  Append some zeros
+-# because we need at least 4 digits for the hex conversion.
+-minver = map(int, string.split('2.3.5', '.')) + [0, 0, 0]
+-minverhex = 0
+-for i in xrange(0, 4): minverhex = (minverhex << 8) + minver[i]
+-sys.exit(sys.hexversion < minverhex)"
+-  if { echo "$as_me:$LINENO: $PYTHON -c "$prog"" >&5
+-   ($PYTHON -c "$prog") >&5 2>&5
+-   ac_status=$?
+-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+-   (exit $ac_status); }; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-else
+-  as_fn_error $? "too old" "$LINENO" 5
+-fi
+-      am_display_PYTHON=$PYTHON
+-    else
+-      # Otherwise, try each interpreter until we find one that satisfies
+-      # VERSION.
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for a Python interpreter with version >= 2.3.5" >&5
+-$as_echo_n "checking for a Python interpreter with version >= 2.3.5... " >&6; }
+-if ${am_cv_pathless_PYTHON+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-	for am_cv_pathless_PYTHON in python python2 python2.4 python2.3 python2.2 python2.1 python2.0 python1.6 python1.5 none; do
+-	  test "$am_cv_pathless_PYTHON" = none && break
+-	  prog="import sys, string
+-# split strings by '.' and convert to numeric.  Append some zeros
+-# because we need at least 4 digits for the hex conversion.
+-minver = map(int, string.split('2.3.5', '.')) + [0, 0, 0]
+-minverhex = 0
+-for i in xrange(0, 4): minverhex = (minverhex << 8) + minver[i]
+-sys.exit(sys.hexversion < minverhex)"
+-  if { echo "$as_me:$LINENO: $am_cv_pathless_PYTHON -c "$prog"" >&5
+-   ($am_cv_pathless_PYTHON -c "$prog") >&5 2>&5
+-   ac_status=$?
+-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+-   (exit $ac_status); }; then :
+-  break
+-fi
+-	done
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_pathless_PYTHON" >&5
+-$as_echo "$am_cv_pathless_PYTHON" >&6; }
+-      # Set $PYTHON to the absolute path of $am_cv_pathless_PYTHON.
+-      if test "$am_cv_pathless_PYTHON" = none; then
+-	PYTHON=:
+-      else
+-        # Extract the first word of "$am_cv_pathless_PYTHON", so it can be a program name with args.
+-set dummy $am_cv_pathless_PYTHON; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_path_PYTHON+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  case $PYTHON in
+-  [\\/]* | ?:[\\/]*)
+-  ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
+-  ;;
+-  *)
+-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_PYTHON="$as_dir/$ac_word$ac_exec_ext"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-  ;;
+-esac
+-fi
+-PYTHON=$ac_cv_path_PYTHON
+-if test -n "$PYTHON"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
+-$as_echo "$PYTHON" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-      fi
+-      am_display_PYTHON=$am_cv_pathless_PYTHON
+-    fi
+-
+-
+-  if test "$PYTHON" = :; then
+-      as_fn_error $? "no suitable Python interpreter found" "$LINENO" 5
+-  else
+-
+-
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON version" >&5
+-$as_echo_n "checking for $am_display_PYTHON version... " >&6; }
+-if ${am_cv_python_version+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_version=`$PYTHON -c "import sys; print sys.version[:3]"`
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_version" >&5
+-$as_echo "$am_cv_python_version" >&6; }
+-  PYTHON_VERSION=$am_cv_python_version
+-
+-
+-
+-  PYTHON_PREFIX='${prefix}'
+-
+-  PYTHON_EXEC_PREFIX='${exec_prefix}'
+-
+-
+-
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON platform" >&5
+-$as_echo_n "checking for $am_display_PYTHON platform... " >&6; }
+-if ${am_cv_python_platform+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_platform=`$PYTHON -c "import sys; print sys.platform"`
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_platform" >&5
+-$as_echo "$am_cv_python_platform" >&6; }
+-  PYTHON_PLATFORM=$am_cv_python_platform
+-
+-
+-
+-
+-                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON script directory" >&5
+-$as_echo_n "checking for $am_display_PYTHON script directory... " >&6; }
+-if ${am_cv_python_pythondir+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_pythondir=`$PYTHON -c "from distutils import sysconfig; print sysconfig.get_python_lib(0,0,prefix='$PYTHON_PREFIX')" 2>/dev/null ||
+-     echo "$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages"`
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pythondir" >&5
+-$as_echo "$am_cv_python_pythondir" >&6; }
+-  pythondir=$am_cv_python_pythondir
+-
+-
+-
+-  pkgpythondir=\${pythondir}/$PACKAGE
+-
+-
+-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $am_display_PYTHON extension module directory" >&5
+-$as_echo_n "checking for $am_display_PYTHON extension module directory... " >&6; }
+-if ${am_cv_python_pyexecdir+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_python_pyexecdir=`$PYTHON -c "from distutils import sysconfig; print sysconfig.get_python_lib(1,0,prefix='$PYTHON_EXEC_PREFIX')" 2>/dev/null ||
+-     echo "${PYTHON_EXEC_PREFIX}/lib/python${PYTHON_VERSION}/site-packages"`
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_python_pyexecdir" >&5
+-$as_echo "$am_cv_python_pyexecdir" >&6; }
+-  pyexecdir=$am_cv_python_pyexecdir
+-
+-
+-
+-  pkgpyexecdir=\${pyexecdir}/$PACKAGE
+-
+-
+-
+-  fi
+-
+-
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for headers required to compile python extensions" >&5
+-$as_echo_n "checking for headers required to compile python extensions... " >&6; }
+-py_prefix=`$PYTHON -c "import sys; print sys.prefix"`
+-py_exec_prefix=`$PYTHON -c "import sys; print sys.exec_prefix"`
+-PYTHON_INCLUDES="-I${py_prefix}/include/python${PYTHON_VERSION}"
+-if test "$py_prefix" != "$py_exec_prefix"; then
+-  PYTHON_INCLUDES="$PYTHON_INCLUDES -I${py_exec_prefix}/include/python${PYTHON_VERSION}"
+-fi
+-
+-save_CPPFLAGS="$CPPFLAGS"
+-CPPFLAGS="$CPPFLAGS $PYTHON_INCLUDES"
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <Python.h>
+-_ACEOF
+-if ac_fn_c_try_cpp "$LINENO"; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: found" >&5
+-$as_echo "found" >&6; }
+-
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+-$as_echo "not found" >&6; }
+-as_fn_error $? "could not find Python headers" "$LINENO" 5
+-fi
+-rm -f conftest.err conftest.i conftest.$ac_ext
+-CPPFLAGS="$save_CPPFLAGS"
+-
+-
+-
+-pkg_failed=no
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for APPINDICATOR_PYTHON" >&5
+-$as_echo_n "checking for APPINDICATOR_PYTHON... " >&6; }
+-
+-if test -n "$APPINDICATOR_PYTHON_CFLAGS"; then
+-    pkg_cv_APPINDICATOR_PYTHON_CFLAGS="$APPINDICATOR_PYTHON_CFLAGS"
+- elif test -n "$PKG_CONFIG"; then
+-    if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"
+-					pygtk-2.0 >= \$PYGTK_REQUIRED
+-					gtk+-2.0 >= \$GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= \$PYGOBJECT_REQUIRED
+-                  \""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  ") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then
+-  pkg_cv_APPINDICATOR_PYTHON_CFLAGS=`$PKG_CONFIG --cflags "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  " 2>/dev/null`
+-		      test "x$?" != "x0" && pkg_failed=yes
+-else
+-  pkg_failed=yes
+-fi
+- else
+-    pkg_failed=untried
+-fi
+-if test -n "$APPINDICATOR_PYTHON_LIBS"; then
+-    pkg_cv_APPINDICATOR_PYTHON_LIBS="$APPINDICATOR_PYTHON_LIBS"
+- elif test -n "$PKG_CONFIG"; then
+-    if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"
+-					pygtk-2.0 >= \$PYGTK_REQUIRED
+-					gtk+-2.0 >= \$GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= \$PYGOBJECT_REQUIRED
+-                  \""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  ") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then
+-  pkg_cv_APPINDICATOR_PYTHON_LIBS=`$PKG_CONFIG --libs "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  " 2>/dev/null`
+-		      test "x$?" != "x0" && pkg_failed=yes
+-else
+-  pkg_failed=yes
+-fi
+- else
+-    pkg_failed=untried
+-fi
+-
+-
+-
+-if test $pkg_failed = yes; then
+-   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-
+-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+-        _pkg_short_errors_supported=yes
+-else
+-        _pkg_short_errors_supported=no
+-fi
+-        if test $_pkg_short_errors_supported = yes; then
+-	        APPINDICATOR_PYTHON_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  " 2>&1`
+-        else
+-	        APPINDICATOR_PYTHON_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  " 2>&1`
+-        fi
+-	# Put the nasty error message in config.log where it belongs
+-	echo "$APPINDICATOR_PYTHON_PKG_ERRORS" >&5
+-
+-	as_fn_error $? "Package requirements (
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  ) were not met:
+-
+-$APPINDICATOR_PYTHON_PKG_ERRORS
+-
+-Consider adjusting the PKG_CONFIG_PATH environment variable if you
+-installed software in a non-standard prefix.
+-
+-Alternatively, you may set the environment variables APPINDICATOR_PYTHON_CFLAGS
+-and APPINDICATOR_PYTHON_LIBS to avoid the need to call pkg-config.
+-See the pkg-config man page for more details." "$LINENO" 5
+-elif test $pkg_failed = untried; then
+-     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+-is in your PATH or set the PKG_CONFIG environment variable to the full
+-path to pkg-config.
+-
+-Alternatively, you may set the environment variables APPINDICATOR_PYTHON_CFLAGS
+-and APPINDICATOR_PYTHON_LIBS to avoid the need to call pkg-config.
+-See the pkg-config man page for more details.
+-
+-To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-	APPINDICATOR_PYTHON_CFLAGS=$pkg_cv_APPINDICATOR_PYTHON_CFLAGS
+-	APPINDICATOR_PYTHON_LIBS=$pkg_cv_APPINDICATOR_PYTHON_LIBS
+-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-
+-fi
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pygtk defs" >&5
+-$as_echo_n "checking for pygtk defs... " >&6; }
+-PYGTK_DEFSDIR=`$PKG_CONFIG --variable=defsdir pygtk-2.0`
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYGTK_DEFSDIR" >&5
+-$as_echo "$PYGTK_DEFSDIR" >&6; }
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pygtk codegen" >&5
+-$as_echo_n "checking for pygtk codegen... " >&6; }
+-PYGTK_CODEGEN="$PYTHON `$PKG_CONFIG --variable=codegendir pygtk-2.0`/codegen.py"
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYGTK_CODEGEN" >&5
+-$as_echo "$PYGTK_CODEGEN" >&6; }
+ 
+ #########################
+ # Check if build tests
+@@ -14358,7 +14001,7 @@ fi
+ # Files
+ ###########################
+ 
+-ac_config_files="$ac_config_files Makefile src/Makefile src/appindicator-0.1.pc src/appindicator3-0.1.pc bindings/Makefile bindings/python/Makefile bindings/python/appindicator.override bindings/vala/Makefile bindings/vala/examples/Makefile tests/Makefile example/Makefile docs/Makefile docs/reference/Makefile docs/reference/version.xml docs/reference/libappindicator-docs.sgml"
++ac_config_files="$ac_config_files Makefile src/Makefile src/appindicator-0.1.pc src/appindicator3-0.1.pc bindings/Makefile bindings/vala/Makefile bindings/vala/examples/Makefile tests/Makefile example/Makefile docs/Makefile docs/reference/Makefile docs/reference/version.xml docs/reference/libappindicator-docs.sgml"
+ 
+ 
+ if test "x$has_mono" = "xtrue" ; then
+@@ -15437,8 +15080,6 @@ do
+     "src/appindicator-0.1.pc") CONFIG_FILES="$CONFIG_FILES src/appindicator-0.1.pc" ;;
+     "src/appindicator3-0.1.pc") CONFIG_FILES="$CONFIG_FILES src/appindicator3-0.1.pc" ;;
+     "bindings/Makefile") CONFIG_FILES="$CONFIG_FILES bindings/Makefile" ;;
+-    "bindings/python/Makefile") CONFIG_FILES="$CONFIG_FILES bindings/python/Makefile" ;;
+-    "bindings/python/appindicator.override") CONFIG_FILES="$CONFIG_FILES bindings/python/appindicator.override" ;;
+     "bindings/vala/Makefile") CONFIG_FILES="$CONFIG_FILES bindings/vala/Makefile" ;;
+     "bindings/vala/examples/Makefile") CONFIG_FILES="$CONFIG_FILES bindings/vala/examples/Makefile" ;;
+     "tests/Makefile") CONFIG_FILES="$CONFIG_FILES tests/Makefile" ;;
+diff --git a/configure.ac b/configure.ac
+index ee03390..4713b22 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -181,33 +181,6 @@ AM_CONDITIONAL(BUILD_MONO_TEST, test x${have_nunit} = xyes)
+ with_localinstall="no"
+ AC_ARG_ENABLE(localinstall, AS_HELP_STRING([--enable-localinstall], [install all of the files localy instead of system directories (for distcheck)]), with_localinstall=$enableval, with_localinstall=no)
+ 
+-###########################
+-# Python
+-###########################
+-
+-PYGTK_REQUIRED=2.14.0
+-PYGOBJECT_REQUIRED=0.22
+-
+-AM_PATH_PYTHON(2.3.5)
+-AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(could not find Python headers)])
+-
+-PKG_CHECK_MODULES(APPINDICATOR_PYTHON,
+-                  [
+-					pygtk-2.0 >= $PYGTK_REQUIRED
+-					gtk+-2.0 >= $GTK_REQUIRED_VERSION
+-					pygobject-2.0 >= $PYGOBJECT_REQUIRED
+-                  ])
+-
+-AC_MSG_CHECKING(for pygtk defs)
+-PYGTK_DEFSDIR=`$PKG_CONFIG --variable=defsdir pygtk-2.0`
+-AC_SUBST(PYGTK_DEFSDIR)
+-AC_MSG_RESULT($PYGTK_DEFSDIR)
+-
+-AC_MSG_CHECKING(for pygtk codegen)
+-PYGTK_CODEGEN="$PYTHON `$PKG_CONFIG --variable=codegendir pygtk-2.0`/codegen.py"
+-AC_SUBST(PYGTK_CODEGEN)
+-AC_MSG_RESULT($PYGTK_CODEGEN)
+-
+ #########################
+ # Check if build tests
+ #########################
+@@ -239,8 +212,6 @@ src/Makefile
+ src/appindicator-0.1.pc
+ src/appindicator3-0.1.pc
+ bindings/Makefile
+-bindings/python/Makefile
+-bindings/python/appindicator.override
+ bindings/vala/Makefile
+ bindings/vala/examples/Makefile
+ tests/Makefile

--- a/flatpak/shared-modules/libappindicator/patches/0003-libappindicator-fix-crash-from-incorrect-signal-emission.patch
+++ b/flatpak/shared-modules/libappindicator/patches/0003-libappindicator-fix-crash-from-incorrect-signal-emission.patch
@@ -1,0 +1,74 @@
+--- libappindicator-12.10.0/src/app-indicator.c	2012-07-11 13:28:34.415113869 -0400
++++ wrk/src/app-indicator.c	2020-03-19 12:14:47.813191652 -0400
+@@ -443,7 +443,7 @@
+ 	                                  G_STRUCT_OFFSET (AppIndicatorClass, new_icon),
+ 	                                  NULL, NULL,
+ 	                                  g_cclosure_marshal_VOID__VOID,
+-	                                  G_TYPE_NONE, 0, G_TYPE_NONE);
++	                                  G_TYPE_NONE, 0);
+ 
+ 	/**
+ 	 * AppIndicator::new-attention-icon:
+@@ -457,7 +457,7 @@
+ 	                                            G_STRUCT_OFFSET (AppIndicatorClass, new_attention_icon),
+ 	                                            NULL, NULL,
+ 	                                            g_cclosure_marshal_VOID__VOID,
+-	                                            G_TYPE_NONE, 0, G_TYPE_NONE);
++	                                            G_TYPE_NONE, 0);
+ 
+ 	/**
+ 	 * AppIndicator::new-status:
+@@ -505,7 +505,7 @@
+ 	                                            G_STRUCT_OFFSET (AppIndicatorClass, connection_changed),
+ 	                                            NULL, NULL,
+ 	                                            g_cclosure_marshal_VOID__BOOLEAN,
+-	                                            G_TYPE_NONE, 1, G_TYPE_BOOLEAN, G_TYPE_NONE);
++	                                            G_TYPE_NONE, 1, G_TYPE_BOOLEAN);
+ 
+ 	/**
+ 	 * AppIndicator::new-icon-theme-path:
+@@ -1175,7 +1175,7 @@
+ 	gchar * guide = priv->label_guide != NULL ? priv->label_guide : "";
+ 
+ 	g_signal_emit(G_OBJECT(self), signals[NEW_LABEL], 0,
+-	              label, guide, TRUE);
++	              label, guide);
+ 	if (priv->dbus_registration != 0 && priv->connection != NULL) {
+ 		GError * error = NULL;
+ 
+@@ -1490,7 +1490,7 @@
+ static void
+ theme_changed_cb (GtkIconTheme * theme, gpointer user_data)
+ {
+-	g_signal_emit (user_data, signals[NEW_ICON], 0, TRUE);
++	g_signal_emit (user_data, signals[NEW_ICON], 0);
+ 
+ 	AppIndicator * self = (AppIndicator *)user_data;
+ 	AppIndicatorPrivate *priv = self->priv;
+@@ -1904,7 +1904,7 @@
+ 	}
+ 
+ 	if (changed) {
+-		g_signal_emit (self, signals[NEW_ATTENTION_ICON], 0, TRUE);
++		g_signal_emit (self, signals[NEW_ATTENTION_ICON], 0);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;
+@@ -1982,7 +1982,7 @@
+ 	}
+ 
+ 	if (changed) {
+-		g_signal_emit (self, signals[NEW_ICON], 0, TRUE);
++		g_signal_emit (self, signals[NEW_ICON], 0);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;
+@@ -2048,7 +2048,7 @@
+ 
+ 		self->priv->icon_theme_path = g_strdup(icon_theme_path);
+ 
+-		g_signal_emit (self, signals[NEW_ICON_THEME_PATH], 0, self->priv->icon_theme_path, TRUE);
++		g_signal_emit (self, signals[NEW_ICON_THEME_PATH], 0, self->priv->icon_theme_path);
+ 
+ 		if (self->priv->dbus_registration != 0 && self->priv->connection != NULL) {
+ 			GError * error = NULL;

--- a/flatpak/shared-modules/libappindicator/patches/0004-libappindicator-fix-crash-iterating-icon-themes.patch
+++ b/flatpak/shared-modules/libappindicator/patches/0004-libappindicator-fix-crash-iterating-icon-themes.patch
@@ -1,0 +1,11 @@
+--- libappindicator-12.10.0/src/app-indicator.c
++++ libappindicator-12.10.0/src/app-indicator.c
+@@ -1606,7 +1606,7 @@ status_icon_changes (AppIndicator * self, gpointer data)
+ 		gint n_elements, i;
+ 		gboolean found=FALSE;
+ 		gtk_icon_theme_get_search_path(icon_theme, &path, &n_elements);
+-		for (i=0; i< n_elements || path[i] == NULL; i++) {
++		for (i=0; i< n_elements; i++) {
+ 			if(g_strcmp0(path[i], self->priv->icon_theme_path) == 0) {
+ 				found=TRUE;
+ 				break;

--- a/scripts/build-flatpak.sh
+++ b/scripts/build-flatpak.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build Hoard as a Flatpak for local testing.
+#
+# Follows the "closed source" recipe from the Tauri docs
+# (https://v2.tauri.app/distribute/flatpak/): build the app's own .deb the
+# normal way, then have flatpak-builder unpack it into /app instead of
+# re-building Rust + the frontend inside the sandbox. That keeps this script
+# consistent with everything else here (scripts/build-sidecar.sh, CI) instead
+# of maintaining a second, sandboxed build path with its own vendored
+# cargo/node sources.
+#
+# Usage:
+#	 scripts/build-flatpak.sh						# build + --install --user, ready to `flatpak run services.hoard.saves`
+#	 scripts/build-flatpak.sh --bundle	 # also produce flatpak/hoard.flatpak (single-file, for sharing)
+set -euo pipefail
+
+HOARD="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FP="$HOARD/flatpak"
+APP_ID="services.hoard.saves"
+RUNTIME_VERSION="50"
+
+want_bundle=0
+for arg in "$@"; do
+	case "$arg" in
+		--bundle) want_bundle=1 ;;
+		*) echo "unknown argument: $arg" >&2; exit 1 ;;
+	esac
+done
+
+for tool in flatpak flatpak-builder ar tar pnpm cargo; do
+	command -v "$tool" >/dev/null 2>&1 || {
+		echo "ERROR: '$tool' is required but not on PATH." >&2
+		exit 1
+	}
+done
+
+if ! flatpak remote-list --user 2>/dev/null | grep -q '^flathub'; then
+	echo "Adding the flathub remote (--user)..."
+	flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+fi
+
+if ! flatpak info --user "org.gnome.Platform//$RUNTIME_VERSION" >/dev/null 2>&1; then
+	echo "Installing org.gnome.Platform//$RUNTIME_VERSION + org.gnome.Sdk//$RUNTIME_VERSION..."
+	flatpak install --user --noninteractive -y flathub \
+		"org.gnome.Platform//$RUNTIME_VERSION" "org.gnome.Sdk//$RUNTIME_VERSION"
+fi
+
+# The three externalBin sidecars every desktop bundle needs (see
+# scripts/build-sidecar.sh for why: overlay, sync daemon, CLI).
+echo "==> Building sidecars"
+bash "$HOARD/scripts/build-sidecar.sh"
+
+echo "==> Building frontend"
+pnpm --dir "$HOARD/crates/hoard-desktop/ui" install --frozen-lockfile
+pnpm --dir "$HOARD/crates/hoard-desktop/ui" build
+
+# tauri-cli isn't a checked-in dependency (CI drives builds through the
+# tauri-apps/tauri-action GitHub Action instead), so pull it via `pnpm dlx`
+# rather than requiring a global install or touching package.json/lockfiles.
+echo "==> Building .deb (cargo tauri build --bundles deb)"
+( cd "$HOARD/crates/hoard-desktop" && pnpm dlx @tauri-apps/cli@2 build --bundles deb )
+
+deb="$(find "$HOARD/target/release/bundle/deb" -maxdepth 1 -name '*.deb' -print -quit)"
+[ -n "$deb" ] || { echo "ERROR: no .deb found under target/release/bundle/deb" >&2; exit 1; }
+echo "Using $deb"
+cp "$deb" "$FP/hoard.deb"
+
+echo "==> Running flatpak-builder"
+rm -rf "$FP/build-dir"
+flatpak-builder --force-clean --user --install --repo="$FP/repo" \
+	"$FP/build-dir" "$FP/$APP_ID.yml"
+
+rm -f "$FP/hoard.deb"
+
+if [ "$want_bundle" -eq 1 ]; then
+	echo "==> Building single-file bundle"
+	flatpak build-bundle "$FP/repo" "$FP/hoard.flatpak" "$APP_ID"
+	echo "Bundle: $FP/hoard.flatpak"
+fi
+
+echo
+echo "Done. Run it with:"
+echo "	flatpak run $APP_ID"


### PR DESCRIPTION
The website shows Hoard sharing saves to a steam deck. Since AppImages aren't exactly "installed", add a flatpak so Hoard can be installed and updated from Flathub.

<!-- Thanks for the PR! A few quick checks first. -->

## What does this change?

Adds a flatpak build manifest and a script to actually build it

## Checklist

- [x] I ran `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`,
      and `cargo test --workspace`.
  - as far as I can see, these are unrelated to my changes
- [x] My commits carry no AI-tool co-author trailers (`Co-authored-by:
      Cursor`, `Copilot`, …). Credit stays with the humans who wrote
      the patch.
- [x] If I added/changed a `query!` or `query_as!`, I regenerated and
      committed `.sqlx/`.
- [x] If I added a new SQL migration, I did **not** modify any existing
      released migration.
- [x] I updated `CHANGELOG.md` under `[Unreleased]` if this is
      user-visible.
  - not user visible unless it is actually made available on Flathub.
    Would be better suited to be added to the changelog with the flathub-docs, once they land.
- [x] I updated docs (`docs/`, `README.md`) if this changes user-facing
      behavior.
