### PR TITLE
bump the pinned actions across their majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    # Ten, not five: five was exactly the number of actions that had a major
+    # waiting, so the cap stayed saturated and hid every other outdated one
+    # behind it. Dependabot never opens the eleventh, it just goes quiet.
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 9
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: pnpm
@@ -128,7 +128,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 9
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: runner.os == 'Linux'
         with:
           node-version: "24"
@@ -193,7 +193,7 @@ jobs:
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 9
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           version: 10
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -30,7 +30,7 @@ jobs:
       # linux/arm64 is emulated via QEMU (many NAS boxes are arm64). The
       # emulated Rust release build is slow but only runs once per release. If
       # your target is x86-only, drop arm64 from `platforms` below to halve it.
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
@@ -97,7 +97,7 @@ jobs:
             type=raw,value=edge,enable=${{ github.ref_type != 'tag' }}
 
       - name: Build + push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deploy/docker/Dockerfile

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           version: 9
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           cache: pnpm
@@ -149,7 +149,7 @@ jobs:
         run: pnpm --dir crates/hoard-desktop/ui install --frozen-lockfile
 
       - name: Build desktop bundle
-        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           # When we set up code signing, these are the env vars the Tauri
           # action picks up:
@@ -293,7 +293,7 @@ jobs:
           ( cd dist && for f in *; do sha256_cmd "$f" > "$f.sha256"; done )
           echo "label=${{ matrix.label }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hoard-desktop-${{ matrix.label }}
           path: dist/*
@@ -307,7 +307,7 @@ jobs:
     # (manual cancel) and on `workflow_dispatch` runs with no tag.
     if: ${{ (success() || failure()) && startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
       # scripts) and so must never see MINISIGN_SECRET_KEY — a malicious dep
       # could otherwise exfiltrate the release-signing key. We only emit the
       # unsigned tarball + checksum as artifacts.
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.package.outputs.artifact }}
           path: |
@@ -146,7 +146,7 @@ jobs:
     # with required reviewers so the signing key can't be used by an
     # unreviewed workflow run.
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -190,7 +190,7 @@ jobs:
           done
 
           rm -f minisign.key
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signatures
           path: dist/*.minisig
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
Supersedes the five Dependabot PRs (#11 #12 #13 #14 #15) and adds the one the cap was hiding.

| action | from | to |
| --- | --- | --- |
| actions/setup-node | v4 | v7.0.0 |
| actions/upload-artifact | v4 | v7.0.1 |
| actions/download-artifact | v4 | v8.0.1 |
| docker/setup-qemu-action | v3 | v4.2.0 |
| docker/build-push-action | v6 | v7.3.0 |
| tauri-apps/tauri-action | v0 | v1.0.0 |

`download-artifact` is the one Dependabot never proposed: `open-pull-requests-limit` was 5 and those five majors filled it exactly, so it stayed quiet about everything behind them. It cannot be left behind anyway — both release workflows upload in one job and download in the next to sign the result, and the halves only talk if they share an `@actions/artifact` major (2.x on the old v4 pair, 6.x on the new one). Bumping upload alone would have looked fine until the next tag.

The cap is now 10, which should surface the seven other actions still a major behind (checkout, login, setup-buildx, metadata, action-gh-release, and both pnpm/action-setup pins).

Checked before pushing:

- every new SHA resolves to the tag its comment claims, against the upstream ref
- every `with:` key across all 53 steps still exists in the pinned version, none deprecated, no new required input
- all six bundles load and reach input parsing under node — the real risk here, since setup-node, setup-qemu and build-push all moved to ESM in these majors
- tauri-action 1.0 with an empty `tagName` and no `releaseId` still builds and skips every upload, so its renamed release-asset handling never reaches us; `Collect bundles` finds bundles by extension under the target dir, which the Tauri CLI writes, not the action

All six now run on node24, needing runner 2.327.1 or later. Every job here is GitHub-hosted, so that is already met.