### PR TITLE
bump five more pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: System deps
         run: |
           sudo apt-get update
@@ -137,7 +137,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: System deps
         if: runner.os == 'Linux'
         run: |
@@ -201,7 +201,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # hoard-desktop is in the workspace and `cargo sqlx prepare --workspace`
       # invokes the build script for every member crate, including the Tauri
       # shell. Without these system libs (and the prebuilt frontend that
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check bans licenses advisories sources
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: steps.registries.outputs.hub == 'true'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Derive tags + labels
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ steps.registries.outputs.images }}
           # v1.2.3 -> :1.2.3, :1.2, and :latest (default flavor latest=auto).

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -104,7 +104,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           # Tauri's `target/` lives under `crates/hoard-desktop/`-adjacent
           # paths in our setup — but the workspace target is the canonical
@@ -347,7 +347,7 @@ jobs:
           rm -f minisign.key
           ls -la dist/
       - name: Upload to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref_name }}
           # Don't recreate the release; just upload more files into it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: System deps
         # libdbus-1-dev is needed by `libdbus-sys`, pulled in transitively via
         # hoard-cli → hoard-agent → keyring (its `sync-secret-service` feature).
@@ -209,7 +209,7 @@ jobs:
       - name: List artifacts
         run: ls -la dist/
       - name: Create release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
The five Dependabot opened once the cap went to ten (#22 #23 #24 #25 #26), four of them taken as proposed and one corrected.

| action | from | to | |
| --- | --- | --- | --- |
| softprops/action-gh-release | v2 | v3.0.3 | as proposed |
| docker/login-action | v3 | v4.6.0 | as proposed |
| docker/metadata-action | v5 | v6.2.0 | as proposed |
| EmbarkStudios/cargo-deny-action | v2.0.20 | v2.1.1 | as proposed |
| Swatinem/rust-cache | v2 | v2.9.2 | **corrected** |

All three majors are the same major: node20 -> node24 runtime, bundle to ESM, nothing functional. metadata-action 6 changes how list inputs treat `#`, but neither `images:` nor `tags:` contains one — the explanatory comments sit above the block scalar, not inside it.

**#25 is the one to look at.** Its title gives it away: "from e18b4977 to f0d9c388", by SHA rather than by version. The SHA we had pinned was not a release either, so Dependabot has no version to compare and falls back to following the default branch — f0d9c388 is that branch's head, a merge commit with no tag on it. Taking it would have pinned us to code the author never cut a release from, which is the exact substitution the SHA pins exist to prevent.

This takes 6323deb1 instead, the commit v2.9.2 actually points at, and writes the version into the trailing comment so the next bump resolves semver rather than chasing the branch. Worth checking the remaining pins that still carry a floating major comment for the same trap.

Checked as before: every SHA resolves to the tag its comment claims (three of these are annotated tags, so they need dereferencing to compare), and every `with:` key still exists in the new version, none deprecated, no new required one.

CI covers rust-cache and cargo-deny-action directly. The other three live in `publish-image.yml` and the release workflows, which only run on a tag, so they rest on the review above.